### PR TITLE
Use indexed sightings array for season queries + normalize heatmap

### DIFF
--- a/app/packages/core/client/controllers/grits_search.coffee
+++ b/app/packages/core/client/controllers/grits_search.coffee
@@ -284,21 +284,17 @@ Template.gritsSearch.onCreated ->
   @autorun =>
     season = @season.get()
     tokens = GritsFilterCriteria.tokens.get()
-    if tokens.length > 0
-      # TODO Other places in the app allow only a single bird name token
-      # so I'm only using the first one for now.
-      token = tokens[0]
     if season
       params =
         season: season
-        birds: [token]
+        birds: tokens
       Template.gritsOverlay.show()
       Meteor.call 'migrationsBySeason', params, (err, result)->
         Template.gritsOverlay.hide()
         if err
           console.log err
           alert("Server error while computing migrations for season.")
-        console.log('result: ', result)
+          return
         map = Template.gritsMap.getInstance()
         # reset the historical heatmap
         heatmapLayerGroup = map.getGritsLayerGroup(GritsConstants.HEATMAP_GROUP_LAYER_ID)
@@ -307,7 +303,7 @@ Template.gritsSearch.onCreated ->
           GritsHeatmapLayer.createLocation(
             season,
             doc,
-            token)
+            tokens)
         heatmapLayerGroup.draw()
   # Public API
   # Currently we declare methods above for documentation purposes then assign

--- a/app/packages/core/client/layers/grits_heatmap.coffee
+++ b/app/packages/core/client/layers/grits_heatmap.coffee
@@ -58,7 +58,6 @@ class GritsHeatmapLayer extends GritsLayer
     data = _locations.concat([[0.0, 0.0, 0]])
     # Normalize the intensity
     totalSightings = data.reduce(((sofar, d)-> sofar + d[2]), 0)
-    console.log totalSightings
     data.forEach((d)-> 100 * d[2] /= totalSightings)
     self._layer.setData(data)
     self._perturbMap()

--- a/app/packages/core/client/layers/grits_heatmap.coffee
+++ b/app/packages/core/client/layers/grits_heatmap.coffee
@@ -59,10 +59,9 @@ class GritsHeatmapLayer extends GritsLayer
     # Normalize the intensity
     totalSightings = data.reduce(((sofar, d)-> sofar + d[2]), 0)
     data.forEach((d)-> 100 * d[2] /= totalSightings)
-    self._layer.setData(data)
-    self._perturbMap()
-    self.hasLoaded.set(true)
-    return
+    @_layer.setData(data)
+    @_perturbMap()
+    @hasLoaded.set(true)
 
   # clears the heatmap
   #

--- a/app/packages/core/package.js
+++ b/app/packages/core/package.js
@@ -73,18 +73,18 @@ Package.onUse(function(api){
     'client/layers/grits_heatmap.coffee',
     'client/templates/header.jade',
     'client/templates/grits_dataTable.jade',
-    'client/templates/grits_dataTable.coffee',
+    'client/controllers/grits_dataTable.coffee',
     'client/templates/grits_layerSelector.jade',
-    'client/templates/grits_layerSelector.coffee',
+    'client/controllers/grits_layerSelector.coffee',
     'client/templates/grits_map.jade',
     'client/templates/grits_map_sidebar.jade',
-    'client/templates/grits_map_sidebar.coffee',
+    'client/controllers/grits_map_sidebar.coffee',
     'client/templates/grits_map_table_sidebar.jade',
-    'client/templates/grits_map.coffee',
+    'client/controllers/grits_map.coffee',
     'client/templates/grits_search.jade',
-    'client/templates/grits_search.coffee',
+    'client/controllers/grits_search.coffee',
     'client/templates/grits_overlay.jade',
-    'client/templates/grits_overlay.coffee'
+    'client/controllers/grits_overlay.coffee'
   ], 'client');
 
   // static assets

--- a/app/packages/core/server/publications.coffee
+++ b/app/packages/core/server/publications.coffee
@@ -221,6 +221,7 @@ migrationsByDates = (dates, tokens, limit, skip) ->
   return matches
 
 migrationsBySeason = (params)->
+  MAX_RESULTS = 500
   query = switch params.season
     when "autumn" then {
       $and: [{
@@ -259,10 +260,11 @@ migrationsBySeason = (params)->
       }]
     }
     else throw new Meteor.Error("Unknown season:" + season)
-  if params.birds?.length == 0
+  if not params.birds or params.birds.length == 0
     throw new Meteor.Error("An array of birds is required.")
   query['sightings.bird_id'] = {$in: params.birds}
   Migrations.find(query, {
+    limit: MAX_RESULTS
     fields:
       loc: 1
       sightings: 1
@@ -271,6 +273,7 @@ migrationsBySeason = (params)->
       state_province: 1
       county: 1
   }).fetch()
+
 
 # count the total migrations for the specified date range
 #

--- a/app/packages/core/server/publications.coffee
+++ b/app/packages/core/server/publications.coffee
@@ -259,9 +259,18 @@ migrationsBySeason = (params)->
       }]
     }
     else throw new Meteor.Error("Unknown season:" + season)
-  for bird in (params.birds or [])
-    query[bird] = {$gte: 1}
-  Migrations.find(query).fetch()
+  if params.birds?.length == 0
+    throw new Meteor.Error("An array of birds is required.")
+  query['sightings.bird_id'] = {$in: params.birds}
+  Migrations.find(query, {
+    fields:
+      loc: 1
+      sightings: 1
+      date: 1
+      country: 1
+      state_province: 1
+      county: 1
+  }).fetch()
 
 # count the total migrations for the specified date range
 #

--- a/app/packages/core/server/startup.coffee
+++ b/app/packages/core/server/startup.coffee
@@ -3,4 +3,6 @@ Meteor.startup ->
   i18n.addLanguage('en', 'English')
 
   # Ensure indexes on migrations
-  Migrations._ensureIndex(date: 1)
+  Migrations._ensureIndex
+    date: 1
+    'sightings.bird_id': 1

--- a/app/packages/core/server/startup.coffee
+++ b/app/packages/core/server/startup.coffee
@@ -5,4 +5,5 @@ Meteor.startup ->
   # Ensure indexes on migrations
   Migrations._ensureIndex
     date: 1
+  Migrations._ensureIndex
     'sightings.bird_id': 1


### PR DESCRIPTION
This update uses the sightings array in migrations to do seasonal searches. It cannot be deployed until the birt database is updated. When I was testing this the fixed-value intensity adjustment where counts were always divided by 1000 was preventing anything from showing up on the heatmap, so I normalized the intensities.