### PR TITLE
default to days and hide the select element

### DIFF
--- a/app/packages/core/client/controllers/grits_search.coffee
+++ b/app/packages/core/client/controllers/grits_search.coffee
@@ -219,10 +219,11 @@ Template.gritsSearch.helpers({
   periods: ->
     return [
       {value: 'days', displayName: i18n.get('gritsSearch.period-days')},
-      {value: 'weeks', displayName: i18n.get('gritsSearch.period-weeks')},
-      {value: 'months', displayName: i18n.get('gritsSearch.period-months')},
-      {value: 'years', displayName: i18n.get('gritsSearch.period-years')}
     ]
+    #  {value: 'weeks', displayName: i18n.get('gritsSearch.period-weeks')},
+    #  {value: 'months', displayName: i18n.get('gritsSearch.period-months')},
+    #  {value: 'years', displayName: i18n.get('gritsSearch.period-years')}
+    #]
   defaultPeriod: (period) ->
     if period.value == 'days'
       return true

--- a/app/packages/core/client/templates/grits_search.jade
+++ b/app/packages/core/client/templates/grits_search.jade
@@ -37,7 +37,7 @@ template(name='gritsSearch')
               span.input-group-addon
                 span.glyphicon.glyphicon-calendar
 
-          .filter-group(style='margin-top: 10px;')
+          .filter-group(style='margin-top: 10px; display: none;')
             label.filter-label {{_ "gritsSearch.period-label"}}
             select#period.form-control.input-sm
               each periods


### PR DESCRIPTION
- the filter defaults to days so the select element was hidden
- the options for 'weeks', 'months', and 'years' have been commented out
within the code