### PR TITLE
Retain date when switching time range

### DIFF
--- a/app/packages/core/client/controllers/grits_search.coffee
+++ b/app/packages/core/client/controllers/grits_search.coffee
@@ -244,37 +244,11 @@ Template.gritsSearch.helpers
     else
       false
 
-  GritsConstants: ->
-    GritsConstants
-
   loadedRecords: ->
     Session.get(GritsConstants.SESSION_KEY_LOADED_RECORDS)
 
   totalRecords: ->
     Session.get(GritsConstants.SESSION_KEY_TOTAL_RECORDS)
-
-  state: ->
-    # GritsFilterCriteria.stateChanged is a reactive-var
-    state = GritsFilterCriteria.stateChanged.get()
-    if _.isNull(state)
-      return
-    if state
-      true
-    else
-      false
-
-  start: ->
-    _initStartDate
-
-  end: ->
-    _initEndDate
-
-  limit: ->
-    if _init
-      # set inital limit
-      _initLimit
-    else
-      GritsFilterCriteria.limit.get()
 
   historicalView: ->
     Template.instance().historicalView.get()
@@ -293,7 +267,6 @@ Template.gritsSearch.helpers
 
   spring: ->
     Template.instance().season.get() == "spring"
-
 
 Template.gritsSearch.onCreated ->
   _initStartDate = GritsFilterCriteria.initStart()

--- a/app/packages/core/client/controllers/grits_search.coffee
+++ b/app/packages/core/client/controllers/grits_search.coffee
@@ -169,8 +169,8 @@ _determineFieldMatchesByWeight = (input, res) ->
 # recursive method to generate suggestions and drive the pagination feature
 _suggestionGenerator = (query, skip, callback) ->
   _matchSkip = skip
-  Meteor.call('typeahead', 'birds', query, skip, (err, res) ->
-    Meteor.call('countTypeaheadBirds', query, (err, count) ->
+  Meteor.call 'typeahead', 'birds', query, skip, (err, res) ->
+    Meteor.call 'countTypeaheadBirds', query, (err, count) ->
       if res.length > 0
         matches = _determineFieldMatchesByWeight(query, res)
         # expects an array of objects with keys [label, value]
@@ -204,7 +204,7 @@ _suggestionGenerator = (query, skip, callback) ->
 
       # bind click handlers
       if !$('.previous-suggestions').hasClass('disabled')
-        $('#previousSuggestions').bind('click', (e) ->
+        $('#previousSuggestions').bind 'click', (e) ->
           e.preventDefault()
           e.stopPropagation()
           if count <= 10 || _matchSkip <= 10
@@ -212,9 +212,9 @@ _suggestionGenerator = (query, skip, callback) ->
           else
             _matchSkip -= 10
           _suggestionGenerator(query, _matchSkip, callback)
-        )
+
       if !$('.next-suggestions').hasClass('disabled')
-        $('#forwardSuggestions').bind('click', (e) ->
+        $('#forwardSuggestions').bind 'click', (e) ->
           e.preventDefault()
           e.stopPropagation()
           if count <= 10
@@ -222,70 +222,78 @@ _suggestionGenerator = (query, skip, callback) ->
           else
             _matchSkip += 10
           _suggestionGenerator(query, _matchSkip, callback)
-          return
-        )
-      return
-    )
-    return
-  )
-  return
 
 # sets an object to be used by Meteors' Blaze templating engine (views)
-Template.gritsSearch.helpers({
+Template.gritsSearch.helpers
   isAnimationRunning: ->
     _animationRunning.get()
+
   periods: ->
-    return [
-      {value: 'days', displayName: i18n.get('gritsSearch.period-days')},
+    [
+      value: 'days'
+      displayName: i18n.get('gritsSearch.period-days')
     ]
     #  {value: 'weeks', displayName: i18n.get('gritsSearch.period-weeks')},
     #  {value: 'months', displayName: i18n.get('gritsSearch.period-months')},
     #  {value: 'years', displayName: i18n.get('gritsSearch.period-years')}
     #]
+
   defaultPeriod: (period) ->
     if period.value == 'days'
-      return true
+      true
     else
-      return false
+      false
+
   GritsConstants: ->
-    return GritsConstants
+    GritsConstants
+
   loadedRecords: ->
-    return Session.get(GritsConstants.SESSION_KEY_LOADED_RECORDS)
+    Session.get(GritsConstants.SESSION_KEY_LOADED_RECORDS)
+
   totalRecords: ->
-    return Session.get(GritsConstants.SESSION_KEY_TOTAL_RECORDS)
+    Session.get(GritsConstants.SESSION_KEY_TOTAL_RECORDS)
+
   state: ->
     # GritsFilterCriteria.stateChanged is a reactive-var
     state = GritsFilterCriteria.stateChanged.get()
     if _.isNull(state)
       return
     if state
-      return true
+      true
     else
-      return false
+      false
+
   start: ->
-    return _initStartDate
+    _initStartDate
+
   end: ->
-    return _initEndDate
+    _initEndDate
+
   limit: ->
     if _init
       # set inital limit
-      return _initLimit
+      _initLimit
     else
-      # reactive var
-      return GritsFilterCriteria.limit.get()
+      GritsFilterCriteria.limit.get()
+
   historicalView: ->
     Template.instance().historicalView.get()
+
   showResults: ->
     Template.instance().historicalView.get() and Session.get(GritsConstants.SESSION_KEY_TOTAL_RECORDS)
+
   summer: ->
     Template.instance().season.get() == "summer"
+
   autumn: ->
     Template.instance().season.get() == "autumn"
+
   winter: ->
     Template.instance().season.get() == "winter"
+
   spring: ->
     Template.instance().season.get() == "spring"
-})
+
 
 Template.gritsSearch.onCreated ->
   _initStartDate = GritsFilterCriteria.initStart()
@@ -295,10 +303,6 @@ Template.gritsSearch.onCreated ->
 
   @season = new ReactiveVar null
   @historicalView = new ReactiveVar true
-  @autorun =>
-    unless @historicalView.get() == 'historicalView'
-      # reset the seaon when the view changes
-      @season.set null
 
   @autorun =>
     season = @season.get()
@@ -327,6 +331,7 @@ Template.gritsSearch.onCreated ->
           heatmapLayerGroup.draw()
       else
         Template.gritsOverlay.hide()
+
   # Public API
   # Currently we declare methods above for documentation purposes then assign
   # to the Template.gritsSearch as a global export
@@ -339,43 +344,30 @@ Template.gritsSearch.onCreated ->
 # triggered when the 'gritsSearch' template is rendered
 Template.gritsSearch.onRendered ->
 
-  searchBar = $('#searchBar').tokenfield({
-    typeahead: [{hint: false, highlight: true}, {
+  searchBar = $('#searchBar').tokenfield
+    typeahead: [{hint: false, highlight: true},
       display: (match) ->
         if _.isUndefined(match)
           return
-        return match.label
+        match.label
       templates:
         suggestion: _suggestionTemplate
         footer: _typeaheadFooter
       source: (query, callback) ->
         _suggestionGenerator(query, 0, callback)
-        return
-    }]
-  })
+    ]
+
   _setSearchBar(searchBar)
   speciesLength = _topSpecies.length - 1
   species = _topSpecies[Math.floor(Math.random() * speciesLength)]
   $('#searchBar').tokenfield('createToken',species);
   # Toast notification options
-  toastr.options = {
-    positionClass: 'toast-bottom-center',
-    preventDuplicates: true,
-  }
-
-  # initialize the DateTimePickers
-  options = {
-    format: 'MM/DD/YY'
-  }
-  startDatePicker = $('#startDate').datetimepicker(options)
-  startDatePicker.data('DateTimePicker').widgetPositioning({vertical: 'bottom', horizontal: 'left'})
-  _setStartDatePicker(startDatePicker)
-  endDatePicker = $('#endDate').datetimepicker(options)
-  endDatePicker.data('DateTimePicker').widgetPositioning({vertical: 'bottom', horizontal: 'left'})
-  _setEndDatePicker(endDatePicker)
+  toastr.options =
+    positionClass: 'toast-bottom-center'
+    preventDuplicates: true
 
   # is the animation running
-  Meteor.autorun ->
+  @autorun ->
     running = GritsHeatmapLayer.animationRunning.get()
     # update the disabled status of the [More] button based loadedRecords
     loadedRecords = Session.get(GritsConstants.SESSION_KEY_LOADED_RECORDS)
@@ -392,6 +384,26 @@ Template.gritsSearch.onRendered ->
         # disable the [More] button
         $('#loadMore').prop('disabled', true)
 
+  @autorun =>
+    if @historicalView.get()
+      # initialize the DateTimePickers
+      Meteor.defer ->
+        _setStartDatePicker(_initDatePicker('startDate', 'dateRangeStart'))
+        _setEndDatePicker(_initDatePicker('endDate', 'dateRangeEnd'))
+    else
+      # reset the season when the view changes
+      @season.set null
+
+_initDatePicker = (elementId, dateName) ->
+  positioning =
+    vertical: 'bottom'
+    horizontal: 'left'
+  picker = $("##{elementId}").datetimepicker
+    format: 'MM/DD/YY'
+    defaultDate: Session.get(dateName)
+  picker.data('DateTimePicker').widgetPositioning(positioning)
+  picker
+
 _changeSearchBarHandler = (e) ->
   combined = []
   tokens =  _searchBar.tokenfield('getTokens')
@@ -401,71 +413,63 @@ _changeSearchBarHandler = (e) ->
     # do nothing
     return
   GritsFilterCriteria.tokens.set(combined)
-  return
-_changeDateHandler = (e) ->
-  $target = $(e.target)
+
+_changeDateHandler = (event) ->
+  $target = $(event.target)
   id = $target.attr('id')
-  if id == 'startDate'
-    if _.isNull(_startDatePicker)
-      return
-    date = _startDatePicker.data('DateTimePicker').date()
-    if date == null
-      return
-    GritsFilterCriteria.operatingDateRangeStart.set(date)
-    Session.set('dateRangeStart', date.toDate())
-    return
-  else if id == 'endDate'
-    if _.isNull(_endDatePicker)
-      return
-    date = _endDatePicker.data('DateTimePicker').date()
-    if date == null
-      return
-    GritsFilterCriteria.operatingDateRangeEnd.set(date)
-    Session.set('dateRangeEnd', date.toDate())
-    return
+  Meteor.defer ->
+    if id == 'startDate'
+      date = getStartDatePicker()?.data('DateTimePicker').date()
+      return if not date
+      GritsFilterCriteria.operatingDateRangeStart.set(date)
+      Session.set('dateRangeStart', date.toDate())
+    else if id == 'endDate'
+      date = getEndDatePicker()?.data('DateTimePicker').date()
+      return if not date
+      GritsFilterCriteria.operatingDateRangeEnd.set(date)
+      Session.set('dateRangeEnd', date.toDate())
+
 _showDateHandler = (e) ->
   $target = $(e.target)
   id = $target.attr('id')
   if id == 'compareDateOverPeriod'
-    if _.isNull(_compareDatePicker)
-      return
-  return
+    return if not _compareDatePicker
+
 _changeLimitHandler = (e) ->
   val = parseInt($("#limit").val(), 10)
   GritsFilterCriteria.limit.set(val)
-  return
+
 _changePeriodHandler = (e) ->
   _lastPeriod = $(e.target).val()
   GritsFilterCriteria.period.set(_lastPeriod)
+
 _applyFilter = (e) ->
   if $(e.target).hasClass('disabled')
     return
   GritsFilterCriteria.apply()
-  return
-# events
-#
-# Event handlers for the grits_filter.html template
+
 Template.gritsSearch.events
   'keyup #searchBar-tokenfield': (e) ->
     if e.keyCode == 13
       if $(e.target).hasClass('disabled')
         return
       GritsFilterCriteria.apply()
-    return
+
   'click #applyFilter': _applyFilter
+
   'change #limit': _changeLimitHandler
+
   'change #searchBar': _changeSearchBarHandler
+
   'dp.change': _changeDateHandler
+
   'dp.show': _showDateHandler
+
   'click #applyFilter': (e) ->
     if $(e.target).hasClass('disabled')
       return
     GritsFilterCriteria.apply()
-    return
-  'click #loadMore': ->
-    GritsFilterCriteria.setOffset()
-    GritsFilterCriteria.more()
-    return
+
   'tokenfield:initialize': (e) ->
     $target = $(e.target)
     $container = $target.closest('.tokenized')
@@ -477,11 +481,10 @@ Template.gritsSearch.events
     $container.find('.token-input.tt-input').css('height', '30px')
     $container.find('.token-input.tt-input').css('font-size', '20px')
     $container.find('.tokenized.main').prepend($("#searchIcon"))
-    $('#' + id + '-tokenfield').on('blur', (e) ->
+    $('#' + id + '-tokenfield').on 'blur', (e) ->
       # only allow tokens
       $container.find('.token-input.tt-input').val("")
-    )
-    return
+
   'tokenfield:createtoken': (e) ->
     $target = $(e.target)
     $container = $target.closest('.tokenized')
@@ -491,21 +494,26 @@ Template.gritsSearch.events
       # do not create a token and clear the input
       $target.closest('.tokenized').find('.token-input.tt-input').val("")
       e.preventDefault()
-    return
+
   'tokenfield:createdtoken': (e) ->
     $target = $(e.target)
     tokens = $target.tokenfield('getTokens')
     token = e.attrs.label
     return false
+
   'tokenfield:removedtoken': (e) ->
     $target = $(e.target)
     tokens = $target.tokenfield('getTokens')
     token = e.attrs.label
     return false
+
   'change #period': _changePeriodHandler
+
   'click .historical-view': (e, instance) ->
     instance.historicalView.set true
+
   'click .seasonal-view': (e, instance) ->
     instance.historicalView.set false
+
   'click .seasons a': (e, instance) ->
     instance.season.set $(e.target).text().toLowerCase()

--- a/app/packages/core/client/grits_filter_criteria.coffee
+++ b/app/packages/core/client/grits_filter_criteria.coffee
@@ -5,22 +5,20 @@ _state = null # keeps track of the query string state
 # local/private minimongo collection
 _Collection = new (Mongo.Collection)(null)
 # local/private Astronomy model for maintaining filter criteria
-_Filter = Astro.Class(
+_Filter = Astro.Class
   name: 'FilterCriteria'
   collection: _Collection
   transform: true
   fields: ['key', 'operator', 'value']
-  validators: {
+  validators:
     key: [
-        Validators.required(),
-        Validators.string()
+      Validators.required(),
+      Validators.string()
     ],
     operator: [
-        Validators.choice(_validOperators)
+      Validators.choice(_validOperators)
     ],
     value: Validators.required()
-  }
-)
 
 # GritsFilterCriteria, this object provides the interface for
 # accessing the UI filter box. The setter methods may be called
@@ -84,7 +82,6 @@ class GritsFilterCriteria
 
     # is the simulation running?
     self.isSimulatorRunning = new ReactiveVar(false)
-    return
   # initialize the start date of the filter 'discontinuedDate'
   #
   # @return [String] dateString, formatted MM/DD/YY
@@ -104,7 +101,7 @@ class GritsFilterCriteria
     yearStr = year.toString().slice(2,4)
     self.operatingDateRangeStart.set(start)
     Session.setDefault('dateRangeStart', start)
-    return "#{month}/#{date}/#{yearStr}"
+    "#{month}/#{date}/#{yearStr}"
   # initialize the end date through the 'effectiveDate' filter
   #
   # @return [String] dateString, formatted MM/DD/YY
@@ -124,7 +121,7 @@ class GritsFilterCriteria
     yearStr = year.toString().slice(2,4)
     self.operatingDateRangeEnd.set(end)
     Session.setDefault('dateRangeEnd', end)
-    return "#{month}/#{date}/#{yearStr}"
+    "#{month}/#{date}/#{yearStr}"
   # initialize the limit through the 'effectiveDate' filter
   #
   # @return [Integer] limit
@@ -133,7 +130,7 @@ class GritsFilterCriteria
     initLimit = self.limit.get()
     self.setLimit(initLimit)
     self._baseState = JSON.stringify(self.getQueryObject())
-    return initLimit
+    initLimit
   # Creates a new filter criteria and adds it to the collection or updates
   # the collection if it already exists
   #
@@ -156,7 +153,7 @@ class GritsFilterCriteria
       if obj.validate() == false
         throw new Error(_.values(obj.getValidationErrors()))
       obj.save()
-      return obj
+      obj
   # removes a FilterCriteria from the collection
   #
   # @param [String] id, the name of the filter criteria
@@ -168,9 +165,9 @@ class GritsFilterCriteria
       obj.remove(cb)
       return
     if obj
-      return obj.remove()
+      obj.remove()
     else
-      return 0
+      0
   # returns the query object used to filter the server-side collection
   #
   # @return [Object] query, a mongoDB query object
@@ -178,7 +175,7 @@ class GritsFilterCriteria
     self = this
     criteria = _Collection.find({})
     result = {}
-    criteria.forEach((filter) ->
+    criteria.forEach (filter) ->
       value = {}
       k = filter.get('key')
       o = filter.get('operator')
@@ -188,15 +185,14 @@ class GritsFilterCriteria
       else
         value[o] = v
       result[k] = value
-    )
-    return result
+    result
   # compares the current state vs. the original/previous state
   compareStates: ->
     self = this
     # postone execution to avoid 'flash' for the fast draw case.  this happens
     # when the user clicks a node or presses enter on the search and the
     # draw completes faster than the debounce timeout
-    async.nextTick( ->
+    async.nextTick ->
       current = self.getCurrentState()
       if current != _state
         # do not notifiy on an empty query or the base state
@@ -209,8 +205,6 @@ class GritsFilterCriteria
           $('#loadMore').prop('disabled', true)
       else
         self.stateChanged.set(false)
-    )
-    return
   # gets the current state of the filter
   #
   # @return [String] the query object JSON.strigify
@@ -229,7 +223,6 @@ class GritsFilterCriteria
     self = this
     query = self.getQueryObject()
     _state = JSON.stringify(query)
-    return
   # process the results of the remote meteor method
   #
   # @param [Array] documents, an Array of mongoDB documents to process
@@ -241,7 +234,6 @@ class GritsFilterCriteria
     period = self.period.get()
     # start the heatmap animation
     GritsHeatmapLayer.startAnimation(startDate, endDate, period, documents, tokens, offset)
-    return
   # applies the filter but does not reset the offset
   #
   # @param [Function] cb, the callback function
@@ -265,10 +257,9 @@ class GritsFilterCriteria
     offset = self.offset.get()
 
     # remove the ignoreFields from the query
-    _.each(_ignoreFields, (field) ->
+    _.each _ignoreFields, (field) ->
       if query.hasOwnProperty(field)
         delete query[field]
-    )
 
     startDate = moment.utc(query.startDate.$gte)
     endDate = moment.utc(query.endDate.$lt)
@@ -291,23 +282,21 @@ class GritsFilterCriteria
       month = compareDate.month()
       dates = _.map(years, (m) -> moment.utc(Date.UTC(m.year(), month, date)).toISOString())
 
-      GritsHeatmapLayer.migrationsByDate(dates, tokens, limit, offset, (err, migrations) ->
+      GritsHeatmapLayer.migrationsByDate dates, tokens, limit, offset, (err, migrations) ->
         if err
           return
         self.process(migrations, tokens, offset)
         # call the original callback function if its defined
         if cb && _.isFunction(cb)
           cb(null, migrations)
-      )
     else
-      GritsHeatmapLayer.migrationsByDateRange(startDate.toISOString(), endDate.toISOString(), tokens, limit, offset, (err, migrations) ->
+      GritsHeatmapLayer.migrationsByDateRange startDate.toISOString(), endDate.toISOString(), tokens, limit, offset, (err, migrations) ->
         if err
           return
         self.process(migrations, tokens, offset)
         # call the original callback function if its defined
         if cb && _.isFunction(cb)
           cb(null, migrations)
-      )
 
   # applies the filter; resets the offset, loadedRecords, and totalRecords
   #
@@ -316,7 +305,7 @@ class GritsFilterCriteria
     self = this
     self.offset.set(0)
     # allow the reactive var to be set before continue
-    async.nextTick( ->
+    async.nextTick ->
       # reset the loadedRecords and totalRecords
       Session.set(GritsConstants.SESSION_KEY_LOADED_RECORDS, 0)
       Session.set(GritsConstants.SESSION_KEY_TOTAL_RECORDS, 0)
@@ -325,8 +314,6 @@ class GritsFilterCriteria
         self.more(cb)
       else
         self.more()
-    )
-    return
   # sets the 'start' date from the filter and updates the filter criteria
   #
   # @param [Object] date, Date object or null to clear the criteria
@@ -356,16 +343,13 @@ class GritsFilterCriteria
     else
       startDatePicker.data('DateTimePicker').date(date)
       self.operatingDateRangeStart.set(date)
-    return
   trackOperatingDateRangeStart: ->
     self = this
     Meteor.autorun ->
       obj = self.operatingDateRangeStart.get()
       self.setOperatingDateRangeStart(obj)
-      async.nextTick( ->
+      async.nextTick ->
         self.compareStates()
-      )
-    return
   # sets the 'end' date from the filter and updates the filter criteria
   #
   # @param [Object] date, Date object or null to clear the criteria
@@ -395,16 +379,13 @@ class GritsFilterCriteria
     else
       endDatePicker.data('DateTimePicker').date(date)
       self.operatingDateRangeEnd.set(date)
-    return
   trackOperatingDateRangeEnd: ->
     self = this
     Meteor.autorun ->
       obj = self.operatingDateRangeEnd.get()
       self.setOperatingDateRangeEnd(obj)
-      async.nextTick( ->
+      async.nextTick ->
         self.compareStates()
-      )
-    return
 
   # set the compare date over period input
   setCompareDateOverPeriod: (date) =>
@@ -431,7 +412,6 @@ class GritsFilterCriteria
     else
       compareDatePicker.data('DateTimePicker').date(date)
       self.compareDateOverPeriod.set(date)
-    return
 
   # set the period dropdown
   setPeriod: (period) ->
@@ -457,16 +437,13 @@ class GritsFilterCriteria
     else
       $('#period').val(period)
       self.period.set(period)
-    return
   trackPeriod: ->
     self = this
     Meteor.autorun ->
       obj = self.period.get()
       self.setPeriod(obj)
-      async.nextTick( ->
+      async.nextTick ->
         self.compareStates()
-      )
-    return
   trackTokens: ->
     self = this
     Meteor.autorun ->
@@ -481,7 +458,6 @@ class GritsFilterCriteria
             # clears the sub-layers and resets the layer group
             if heatmapLayerGroup != null
               heatmapLayerGroup.reset()
-    return
   # sets the limit input on the UI to the 'value'
   # specified, as well as, updating the underlying FilterCriteria.
   #
@@ -507,19 +483,16 @@ class GritsFilterCriteria
         self.createOrUpdate('limit', {key: 'limit', operator: '$eq', value: val})
     else
       self.limit.set(value)
-    return
   trackLimit: ->
     self = this
     Meteor.autorun ->
       obj = self.limit.get()
       try
         self.setLimit(obj)
-        async.nextTick( ->
+        async.nextTick ->
           self.compareStates()
-        )
       catch e
         Meteor.gritsUtil.errorHandler(e)
-    return
   # sets the offest as calculated by the current query that has more results
   # than the limit
   #
@@ -537,6 +510,5 @@ class GritsFilterCriteria
       self.offset.set(loadedRecords)
     else
       self.offset.set(0)
-    return
 
 GritsFilterCriteria = new GritsFilterCriteria() # exports as a singleton

--- a/app/packages/core/client/templates/grits_search.jade
+++ b/app/packages/core/client/templates/grits_search.jade
@@ -16,14 +16,14 @@ template(name='gritsSearch')
       .filter-group
         label.filter-label {{_ "gritsSearch.start-label"}}
         #startDate.input-group.date
-          input.date-button.form-control.input-sm(type='text', value='{{start}}')
+          input.date-button.form-control.input-sm(type='text')
           span.input-group-addon
             span.glyphicon.glyphicon-calendar
 
       .filter-group(style='margin-top: 10px;')
         label.filter-label {{_ "gritsSearch.end-label"}}
         #endDate.input-group.date
-          input.date-button.form-control.input-sm(type='text', value='{{end}}')
+          input.date-button.form-control.input-sm(type='text')
           span.input-group-addon
             span.glyphicon.glyphicon-calendar
 


### PR DESCRIPTION
Fixes [this bug](https://www.pivotaltracker.com/story/show/135212835) causing datepickers to return to their default values.
When the user switched between tabs, the `datepicker` instances were lost. This re-instantiates the pickers in an `autorun` which is triggered by a change in the `historicalView` reactiveVar.