### PR TITLE
Fix main ui for bsve and small screens

### DIFF
--- a/app/packages/core/client/stylesheets/main.styl
+++ b/app/packages/core/client/stylesheets/main.styl
@@ -1,3 +1,4 @@
+@import '{styles-base}/rupture'
 @import '{styles-base}/variables'
 @import '{styles-base}/mixins'
 @import 'globals.import'

--- a/app/packages/core/client/stylesheets/map.import.styl
+++ b/app/packages/core/client/stylesheets/map.import.styl
@@ -1,14 +1,26 @@
-$widthWithoutBothSidebars = $sidebar-main-width + $sidebar-tabular-width
-$tabularSidebarAndMainSidebarMenu = $sidebar-tabular-width + $sidebar-main-menu-width
+$width-with-both-sidebars = $sidebar-main-width + $sidebar-tabular-width
+$width-with-both-sidebars-small = $sidebar-main-width-small + $sidebar-tabular-width-small
+$tabular-sidebar-and-main-sidebar-menu = $sidebar-tabular-width + $sidebar-main-menu-width
+$tabular-sidebar-and-main-sidebar-menu-small = $sidebar-tabular-width-small + $sidebar-main-menu-width-small
+
+$tabular-sidebar-overlaps-content = true
 
 #grits-map
   transition $transition-time $transition-easing
   height 100%
-  width 'calc(100% - %s)' % $widthWithoutBothSidebars
   top 0
   bottom 0
+  width 'calc(100% - %s)' % $width-with-both-sidebars
   right $sidebar-tabular-width
   left $sidebar-main-width
+  +below(3)
+    left $sidebar-main-width-small
+    if $tabular-sidebar-overlaps-content
+      width 'calc(100% - %s)' % $sidebar-main-width-small
+      right 0
+    else
+      width 'calc(100% - %s)' % $width-with-both-sidebars-small
+      right $sidebar-tabular-width-small
 
 .tabular-sidebar-closed
   &.main-sidebar-closed
@@ -16,14 +28,27 @@ $tabularSidebarAndMainSidebarMenu = $sidebar-tabular-width + $sidebar-main-menu-
       width 'calc(100% - %s)' % $sidebar-main-menu-width
       left $sidebar-main-menu-width
       right 0
+      +below(3)
+        width 'calc(100% - %s)' % $sidebar-main-menu-width-small
+        left $sidebar-main-menu-width-small
 
 .main-sidebar-closed
   #grits-map
-    width 'calc(100% - %s)' % $tabularSidebarAndMainSidebarMenu
     left $sidebar-main-menu-width
+    width 'calc(100% - %s)' % $tabular-sidebar-and-main-sidebar-menu
     right $sidebar-tabular-width
+    +below(3)
+      left $sidebar-main-menu-width-small
+      if $tabular-sidebar-overlaps-content
+        width 'calc(100% - %s)' % $sidebar-main-menu-width-small
+        right 0
+      else
+        right $sidebar-tabular-width-small
+        width 'calc(100% - %s)' % $tabular-sidebar-and-main-sidebar-menu-small
 
 .tabular-sidebar-closed
   #grits-map
     width 'calc(100% - %s)' % $sidebar-main-width
     right 0
+    +below(3)
+      width 'calc(100% - %s)' % $sidebar-main-width-small

--- a/app/packages/scrubber/scrubber.coffee
+++ b/app/packages/scrubber/scrubber.coffee
@@ -100,13 +100,13 @@ Template.scrubber.helpers
       'play'
   paused: ->
     if Template.instance().isPaused.get()
-      'scrubber-paused'
+      'scrubber--button-controls--paused'
   playDisabled: ->
     if not GritsFilterCriteria.tokens.get().length
-      'scrubber-play-disabled'
+      'scrubber--button-controls--play--disabled'
   stopDisabled: ->
     if not Template.instance().isPlaying.get()
-      'scrubber-stop-disabled'
+      'scrubber--button-controls--stop--disabled'
   progress: ->
     progress = GritsHeatmapLayer.animationProgress.get()
     return progress * 100 + '%'
@@ -115,8 +115,8 @@ Template.scrubber.events
   'dblclick .scrubber-container': (event) ->
     event.stopImmediatePropagation()
     event.stopPropagation()
-  'click .scrubber-play': (event, instance) ->
-    if ($(event.currentTarget).hasClass('scrubber-play-disabled'))
+  'click .scrubber--button-controls--play': (event, instance) ->
+    if ($(event.currentTarget).hasClass('scrubber--button-controls--play--disabled'))
       return
     isPlaying = instance.isPlaying.get()
     isPaused = instance.isPaused.get()
@@ -125,8 +125,8 @@ Template.scrubber.events
     unless isPlaying
       unless isPaused
         $('#applyFilter').click()
-  'click .scrubber-stop': (event, instance) ->
-    if ($(event.target).hasClass('.scrubber-stop-disabled'))
+  'click .scrubber--button-controls--stop': (event, instance) ->
+    if ($(event.target).hasClass('scrubber--button-controls--stop--disabled'))
       return
     instance.isPlaying.set(false)
     GritsHeatmapLayer.stopAnimation()

--- a/app/packages/scrubber/stylesheets/scrubber.styl
+++ b/app/packages/scrubber/stylesheets/scrubber.styl
@@ -1,4 +1,5 @@
 @import '{styles-base}/variables'
+@import '{styles-base}/rupture'
 
 .leaflet-left.leaflet-bottom
   left 0
@@ -15,8 +16,10 @@
     box-shadow none
     border-radius 0
     font-family $primary-font
-    background alpha($whiteBG, 50%)
+    background alpha($whiteBG, 60%)
     transition .2s
+    +below(3)
+      background alpha($whiteBG, 80%)
     &.active
       background $whiteBG
     h2
@@ -42,30 +45,38 @@
       color $d-gray
       align-self center
 
-.scrubber-container
+.scrubber
   width calc(100% - 120px)
 
-.scrubber-play
-.scrubber-stop
-  width 50px
+.scrubber--button-controls
+  display flex
+
+.scrubber--button-controls--play
+.scrubber--button-controls--stop
   overflow hidden
   cursor pointer
   margin-right 1em
-
-.scrubber-play
+  color $secondary-d
   &:hover
-    color $secondary
+    transform scale(1.1)
+  +below(3)
+    font-size .85em
 
-.scrubber-stop
-  &:not(.scrubber-stop-disabled)
+.scrubber--button-controls--play
+  &:hover
+    color darken($secondary-d, 10%)
+
+.scrubber--button-controls--stop
+  color $delete
+  &:not(.scrubber--button-controls--stop--disabled)
     &:hover
-      color darken($delete, 10%)
+      color darken($delete, 30%)
 
-.scrubber-stop-disabled
-.scrubber-play-disabled
+.scrubber--button-controls--play--disabled
+.scrubber--button-controls--stop--disabled
   opacity .25
 
-.right-slider-container
+.scrubber--right-slider-container
   position relative
   width calc(100% - 60px)
   display flex
@@ -93,23 +104,64 @@
  100%
     -webkit-transform: scale(1)
 
-.scrubber-paused
- -webkit-animation-name 'pulse_animation'
- -webkit-animation-delay 0s
- -webkit-animation-duration 1500ms
- -webkit-animation-iteration-count infinite
- -webkit-animation-timing-function linear
+.scrubber--button-controls--paused
+  -webkit-animation-name 'pulse_animation'
+  -webkit-animation-delay 0s
+  -webkit-animation-duration 1500ms
+  -webkit-animation-iteration-count infinite
+  -webkit-animation-timing-function linear
 
-.scrubber-progress
+.scrubber--progress
   position absolute
   width 2px
-  height 18px
+  height 17px
   top 50%
   transform translate(0, -50%)
-  background-color $primary
+  background-color $secondary-d
   left 0%
   z-index 5
   opacity .7
+  transition .3s
+  +below(3)
+    height 12px
 
-.noUi-handle
-  z-index 10
+.noUi-target
+  border-color darken($secondary, 10%)
+  cursor pointer
+
+.noUi-connect
+  background alpha($secondary, 90%)
+  box-shadow none
+  border 0
+
+.noUi-background
+  background alpha(white, 80%)
+
+.noUi-horizontal
+  +below(3)
+    height 12px
+  .noUi-handle
+    top -9px
+    z-index 10
+    height 2.75em
+    width 2.75em
+    border-radius 50%
+    background $secondary-d
+    border 0
+    box-shadow none
+    transition .1s
+    &:hover
+      transform scale(1.1)
+      background darken($secondary-d, 10%)
+      cursor pointer
+      cursor grab
+      cursor -webkit-grab
+    &:active
+      background $primary
+    +below(3)
+      top -9px
+      height 2.25em
+      width 2.25em
+    &::before
+    &::after
+      display none

--- a/app/packages/scrubber/templates/scrubber.jade
+++ b/app/packages/scrubber/templates/scrubber.jade
@@ -1,8 +1,9 @@
 template(name='scrubber')
-  .scrubber-play(class='{{paused}}')
-    i.fa.fa-4x(class='fa-{{state}}-circle')
-  .scrubber-stop(class='{{stopDisabled}}')
-    i.fa.fa-stop-circle.fa-4x
-  .right-slider-container
+  .scrubber--button-controls
+    .scrubber--button-controls--play(class='{{paused}}')
+      i.fa.fa-4x(class='fa-{{state}}-circle')
+    .scrubber--button-controls--stop(class='{{stopDisabled}}')
+      i.fa.fa-stop-circle.fa-4x
+  .scrubber--right-slider-container
     #slider
-    .scrubber-progress(style='left: {{progress}}')
+    .scrubber--progress(style='left: {{progress}}')

--- a/app/packages/sidebar/base.import.styl
+++ b/app/packages/sidebar/base.import.styl
@@ -1,4 +1,5 @@
 $sidebar-main-content-width = $sidebar-main-width - $sidebar-main-menu-width
+$sidebar-main-content-width-small = $sidebar-main-width-small - $sidebar-main-menu-width-small
 $sidebar-border-width = 3px
 
 .sidebar
@@ -11,11 +12,15 @@ $sidebar-border-width = 3px
   width $sidebar-main-width
   transition $transition-time $transition-easing
   background-color $content-bg
+  +below(3)
+    width $sidebar-main-width-small
   &.off-canvas
     transform translate($sidebar-main-content-width * -1, 0)
     li
       &.active
         color $inactive-btn
+    +below(3)
+      transform translate($sidebar-main-content-width-small * -1, 0)
 
 .sidebar--tab-container
   position absolute
@@ -28,6 +33,8 @@ $sidebar-border-width = 3px
   align-items flex-start
   justify-content center
   border-left $sidebar-border-width solid darken($tabs-bg, 10%)
+  +below(3)
+    width $sidebar-main-menu-width-small
 
 if $sidebar-main-menu-width == 0
   .sidebar
@@ -49,10 +56,14 @@ if $sidebar-main-menu-width == 0
     transition all .2s
     cursor pointer
     text-align center
+    +below(3)
+      font-size $tab-font-size - .4
     &:first-of-type
       margin-bottom 60px
     &.large
       font-size $tab-font-size + .4
+      +below(3)
+        font-size $tab-font-size
     &.push-to-btm
       align-self flex-end
     &.push-to-top
@@ -65,6 +76,8 @@ if $sidebar-main-menu-width == 0
 .sidebar--content
   height 100vh
   margin-right $sidebar-main-menu-width
+  +below(3)
+    margin-right $sidebar-main-menu-width-small
 
 .sidebar--pane
   display none
@@ -83,6 +96,8 @@ if $sidebar-main-menu-width == 0
   bottom 0
   z-index 100
   width 'calc(100% - %s)' % $sidebar-main-menu-width
+  +below(3)
+    width 'calc(100% - %s)' % $sidebar-main-menu-width-small
 
 .help-toggle
   position absolute
@@ -98,13 +113,23 @@ if $sidebar-main-menu-width == 0
   position absolute
   bottom $play-controls-height + 10px
   left $sidebar-main-menu-width + 10px
+  +below(3)
+    bottom $play-controls-height + 5px
+    left $sidebar-main-menu-width
 
 .zoom-control--in
 .zoom-control--out
   color $inactive-btn
   background $tabs-bg
   margin-bottom 5px
-  min-height 35px
+  height 35px
   width 35px
+  display flex
+  align-items center
+  justify-content center
+  +below(3)
+    height 25px
+    width 25px
+    font-size .8em
   &:hover
     color $active-btn

--- a/app/packages/sidebar/main.styl
+++ b/app/packages/sidebar/main.styl
@@ -1,4 +1,5 @@
 @import 'nib'
+@import '{styles-base}/rupture'
 @import '{styles-base}/variables'
 @import '{styles-base}/mixins'
 @import 'variables.import'

--- a/app/packages/sidebar/tabular.import.styl
+++ b/app/packages/sidebar/tabular.import.styl
@@ -6,8 +6,12 @@
   width $sidebar-tabular-width
   z-index 2000
   transition transform $transition-time $transition-easing
+  +below(3)
+    width $sidebar-tabular-width-small
   &.off-canvas
     transform translate($sidebar-tabular-width - 3px, 0)
+    +below(3)
+      transform translate($sidebar-tabular-width-small - 3px, 0)
 
 #tableSidebar
   .sidebar--content

--- a/app/packages/styles/package.js
+++ b/app/packages/styles/package.js
@@ -12,4 +12,5 @@ Package.onUse(function(api) {
   api.addFiles('variables.styl', 'client', {isImport: true});
   api.addFiles('mixins.styl', 'client', {isImport: true});
   api.addFiles('tooltips.styl', 'client', {isImport: true});
+  api.addFiles('rupture.styl', 'client', {isImport: true});
 });

--- a/app/packages/styles/rupture.styl
+++ b/app/packages/styles/rupture.styl
@@ -1,0 +1,268 @@
+// Rupture
+// https://github.com/jescalan/rupture
+
+
+base-font-size ?= 16px
+rasterise-media-queries ?= false
+
+rupture = {
+  rasterise-media-queries: rasterise-media-queries
+  mobile-cutoff: 400px
+  desktop-cutoff: 1050px
+  hd-cutoff: 1800px
+  enable-em-breakpoints: false
+  base-font-size: base-font-size
+  anti-overlap: false
+  density-queries: 'dppx' 'webkit' 'moz' 'dpi'
+  retina-density: 1.5
+  use-device-width: false
+}
+// rupture.scale = 0 (rupture.mobile-cutoff) 600px 800px (rupture.desktop-cutoff) (rupture.hd-cutoff)
+rupture.scale = 0        480px        768px      992px      1200px
+//              └────┬────┘ └────┬────┘ └────┬────┘ └────┬────┘└────┬────┘
+//                   1           2           3           4          5
+
+rupture.scale-names = 'xs' 's' 'm' 'l' 'xl' 'hd'
+
+-is-string(val)
+  if typeof(val) is not 'unit'
+    if val is a 'string' or val is a 'ident'
+      true
+    else
+      false
+  else
+    false
+
+-get-scale-number(scale-name)
+  for list-item, i in rupture.scale-names
+    if list-item is scale-name
+      return i + 1
+  return false
+
+-convert-to(to-unit, value, context = rupture.base-font-size)
+  from-unit = unit(value)
+  return value if to-unit is from-unit
+  if to-unit in ('em' 'rem')
+    return value if from-unit in ('em' 'rem')
+    return unit((value / context), to-unit)
+  if to-unit is 'px'
+    return unit((value * context), 'px')
+
+-on-scale(n)
+  return unit(n) is ''
+
+-larger-than-scale(n)
+  return (n > (length(rupture.scale) - 1)) and -on-scale(n)
+
+-is-zero(n)
+  return n is 0
+
+-overlap-shift(anti-overlap, n)
+  shift-unit = unit(n)
+  anti-overlap = 0px unless anti-overlap
+  anti-overlap = 1px if anti-overlap is true
+  if length(anti-overlap) is 1
+    return -convert-to(shift-unit, anti-overlap)
+  for val in anti-overlap
+    return val if unit(val) is shift-unit
+
+-adjust-overlap(anti-overlap, n, side = 'min')
+  -shift = -overlap-shift(anti-overlap, n)
+  if (side is 'min' and -shift > 0) or (side is 'max' and -shift < 0)
+    n = n + -shift
+  return n
+
+-is-positive(n)
+  return n >= 0
+
+-density-queries(density)
+  if typeof(density) is not 'unit'
+    if not -is-string(density)
+      density = '%s' % density
+  density = rupture.retina-density if density is 'retina'
+  queries = ()
+  for query in rupture.density-queries
+    if query is 'webkit'
+      push(queries, '(-webkit-min-device-pixel-ratio: %s)' % (density))
+    else if query is 'moz'
+      push(queries, '(min--moz-device-pixel-ratio: %s)' % (density))
+    else if query is 'o'
+      push(queries, '(-o-min-device-pixel-ratio: %s/1)' % (density))
+    else if query is 'ratio'
+      push(queries, '(min-device-pixel-ratio: %s)' % (density))
+    else if query is 'dpi'
+      if -is-string(density)
+        density=convert(density)
+      push(queries, '(min-resolution: %sdpi)' % (round(density * 96, 1)))
+    else if query is 'dppx'
+      push(queries, '(min-resolution: %sdppx)' % (density))
+  return queries
+
+create-fallback-class(selected, class)
+  /{'' + class + ' ' + selected}
+    {block}
+
+// +between(min, max)
+// usage (scale can be mixed with custom values):
+//   - +between(1, 3) scale:scale
+//   - +between(0, 3) 0 width:scale
+//   - +between(200px, 500px) custom:custom
+//   - +between(0, 300px) 0 width:custom
+//   - +between(1, 300px) scale:custom
+//   - +between(200px, 4) custom:scale
+
+between(min, max, anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width, fallback-class = null)
+  selected = selector()
+
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
+  if -is-string(min)
+    min = -get-scale-number(min)
+  if -is-string(max)
+    max = -get-scale-number(max)
+
+  -min = rupture.scale[min - 1] unless -is-zero(min) or (not -on-scale(min))
+  -max = rupture.scale[max] unless not -on-scale(max)
+  -min ?= min
+  -max ?= max
+
+  if (rupture.rasterise-media-queries)
+    if not (density or -max or orientation)
+      {block}
+  else
+    condition = 'only screen'
+    use-device-width = use-device-width ? 'device-' : ''
+    unless -min is 0
+      -min = -convert-to('em', -min) if rupture.enable-em-breakpoints
+      -min = -adjust-overlap(anti-overlap, -min, side: 'min')
+      condition = condition + ' and (min-' + use-device-width + 'width: %s)' % (-min)
+    unless -larger-than-scale(max)
+      -max = -convert-to('em', -max) if rupture.enable-em-breakpoints
+      -max = -adjust-overlap(anti-overlap, -max, side: 'max')
+      condition = condition + ' and (max-' + use-device-width + 'width: %s)' % (-max)
+    if orientation
+      condition = condition + ' and (orientation: %s)' % (orientation)
+    if density
+      conditions = ()
+      for query in -density-queries(density)
+        push(conditions, condition + ' and %s' % (query))
+      condition = join(', ', conditions)
+    @media condition
+      {block}
+  if fallback-class
+    +create-fallback-class(selected, fallback-class)
+      {block}
+
+at(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width, fallback-class = null)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
+  +between(scale-point, scale-point, anti-overlap, density, orientation, use-device-width, fallback-class)
+    {block}
+
+from-width(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width, fallback-class = null)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
+  +between(scale-point, length(rupture.scale), anti-overlap, density, orientation, use-device-width, fallback-class)
+    {block}
+
+above = from-width
+
+to-width(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width, fallback-class = null)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
+  +between(1, scale-point, anti-overlap, density, orientation, use-device-width, fallback-class)
+    {block}
+
+below = to-width
+
+mobile(anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width, fallback-class = null)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
+  +below(rupture.mobile-cutoff, anti-overlap, density, orientation, use-device-width, fallback-class)
+    {block}
+
+tablet(anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width, fallback-class = null)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
+  +between(rupture.mobile-cutoff, rupture.desktop-cutoff, anti-overlap, density, orientation, use-device-width, fallback-class)
+    {block}
+
+desktop(anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width, fallback-class = null)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
+  +above(rupture.desktop-cutoff, anti-overlap, density, orientation, use-device-width, fallback-class)
+    {block}
+
+hd(anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width, fallback-class = null)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
+  +above(rupture.hd-cutoff, anti-overlap, density, orientation, use-device-width, fallback-class)
+    {block}
+
+density(density, orientation = null, fallback-class = null)
+  selected = selector()
+  if not (rupture.rasterise-media-queries)
+    conditions = ()
+    for query in -density-queries(density)
+      condition = 'only screen and %s' % (query)
+      if orientation
+        condition = condition + ' and (orientation: %s)' % (orientation)
+      push(conditions, condition)
+    condition = join(', ', conditions)
+    @media condition
+      {block}
+    if fallback-class
+      +create-fallback-class(selected, fallback-class)
+        {block}
+
+pixel-ratio = density
+
+retina(orientation = null, fallback-class = null)
+  +density('retina', orientation, fallback-class)
+    {block}
+
+landscape(density = null, fallback-class = null)
+  selected = selector()
+  if not (rupture.rasterise-media-queries)
+    if -is-string(density)
+      density = convert(density)
+    if density
+      +pixel-ratio(density, orientation: landscape, fallback-class)
+        {block}
+    else
+      @media only screen and (orientation: landscape)
+        {block}
+      if fallback-class
+        +create-fallback-class(selected, fallback-class)
+          {block}
+
+portrait(density = null, fallback-class = null)
+  selected = selector()
+  if not (rupture.rasterise-media-queries)
+    if -is-string(density)
+      density = convert(density)
+    if density
+      +pixel-ratio(density, orientation: portrait, fallback-class)
+        {block}
+    else
+      @media only screen and (orientation: portrait)
+        {block}
+      if fallback-class
+        +create-fallback-class(selected, fallback-class)
+          {block}

--- a/app/packages/styles/variables.styl
+++ b/app/packages/styles/variables.styl
@@ -35,6 +35,9 @@ $modal-z-index = 10000
 $sidebar-main-width      = 350px
 $sidebar-main-menu-width = 50px
 $sidebar-tabular-width   = 580px
+$sidebar-main-width-small      = 300px
+$sidebar-main-menu-width-small = 40px
+$sidebar-tabular-width-small   = 450px
 
 $play-controls-height = 80px
 


### PR DESCRIPTION
This helps some with the UX at smaller screens but isn't really a complete solution.
- slims down the widths of the sidebars on small screens
- adjusts sizing of scrubber components
- allows the tabular sidebar to overlap content on small screens
- adds [Rupture](https://github.com/jescalan/rupture) (the easiest way at this point is to just add a file manually - the current version/structure of the application is not npm freindly and I can't find a decent standalone Rupture package)